### PR TITLE
Add caching for find results

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ These include:
     This feature will save intermediate processing results to cache which can later be used to greatly reduce query time.
     Especially useful when the JSON is big (millions of records) and queries are similar.
 
-    Example:
+    Example (enabling caching):
     ```js
     var jsonQuery = require('query');
-    var jq = jsonQuery({cacheData: true});
+    var jq = jsonQuery({cacheData: true}); // Create a JsonQuery object with cache
 
     // First query - updates the cache
     var _res1 = jq.query("$..[?year>2000]", data);
@@ -60,6 +60,22 @@ These include:
     var _res2 = jq.query("$..[?year>1976]", data);
     console.log(_res2);
     ```
+
+    Example 2 (caching disabled, works same as original implementation):
+    ```js
+    var jsonQuery = require('query');
+    var jq = jsonQuery(); // JsonQuery without cache
+
+    // First query 
+    var _res1 = jq.query("$..[?year>2000]", data);
+    console.log(_res1);
+
+    // Second query - will take same amount of time as first query
+    var _res2 = jq.query("$..[?year>1976]", data);
+    console.log(_res2);
+    ```
+
+    Note: Enabling caching will incur increased the memory usage that will persist as long as the JsonQuery object is alive 
 # Quality Assurance
 Since the code is same as [Dojox/Json/Query](https://github.com/maqetta/dojox/blob/master/json/query.js). Its Quality is also same. Because it is in [Dojox](https://github.com/dojo/dojox) not in [Dojo](https://github.com/dojo/dojo), it may have some issues.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ These include:
     // ['bands']['Dire Straits']['albums']['1']
     ```
 
+2) Caching (Currently not supported when running in browser):
+    This feature will save intermediate processing results to cache which can later be used to greatly reduce query time.
+    Especially useful when the JSON is big (millions of records) and queries are similar.
+
+    Example:
+    ```js
+    var jsonQuery = require('query');
+    var jq = jsonQuery({cacheData: true});
+
+    // First query - updates the cache
+    var _res1 = jq.query("$..[?year>2000]", data);
+    console.log(_res1);
+
+    // Second query - will take signifcantly less time to perform (on large data sets)
+    var _res2 = jq.query("$..[?year>1976]", data);
+    console.log(_res2);
+    ```
 # Quality Assurance
 Since the code is same as [Dojox/Json/Query](https://github.com/maqetta/dojox/blob/master/json/query.js). Its Quality is also same. Because it is in [Dojox](https://github.com/dojo/dojox) not in [Dojo](https://github.com/dojo/dojo), it may have some issues.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json_query",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/query.js
+++ b/query.js
@@ -58,6 +58,15 @@ jsonQuery._find = function e(obj,name){
       }
     }
   }
+
+  // If using cache, take results from it if exists
+  if (this.cacheData && this.cache[name]) {
+    cached_results = this.cache[name].get(obj);
+    if (cached_results) {
+        return cached_results;
+    }
+  }
+
   if(name instanceof Array){
     // this is called when multiple items are in the brackets: [3,4,5]
     if(name.length==1){
@@ -73,6 +82,15 @@ jsonQuery._find = function e(obj,name){
     // otherwise we expanding
     walk(obj);
   }
+
+  // If using cache, update it
+  if (this.cacheData) {
+    if (!this.cache[name]) {
+      this.cache[name] = new WeakMap();
+    }
+    this.cache[name].set(obj, results);
+  }
+
   return results;
 },
 jsonQuery.map = function(arr, callback, thisObject, Ctr){
@@ -372,7 +390,9 @@ if(typeof module != 'undefined' && module.exports) {
     if (params) {
       for (var attrname in params) { jsonQuery[attrname] = params[attrname]; }
     }
-
+    if (jsonQuery['cacheData']) {
+      jsonQuery['cache'] = {};
+    }
     return jsonQuery
   }  
 }

--- a/query.js
+++ b/query.js
@@ -36,6 +36,11 @@ jsonQuery._slice = function(obj,start,end,step){
 jsonQuery._find = function e(obj,name){
   // handles ..name, .*, [*], [val1,val2], [val]
   // name can be a property to search for, undefined for full recursive, or an array for picking by index
+
+  // Save some work and avoid saving to cache later
+  if (typeof obj === "undefined")
+    return undefined;
+
   var results = [];
   function walk(obj){
     if(name){

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,9 @@ describe('deepSearchWithCaching', function() {
 });
 
 describe('deepSearchForLargeData', function() {
+
+  this.timeout(4000);
+
   big_data = {
     groups: [],
     creator: "Me"

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ var should = require('chai').should(),
 var data = [{"name":"harpreet","age":25,"subjects":[{"name":"English","class":"8"},{"name":"Hindi","class":"8"},{"name":"Math","class":"8"},{"name":"Science","class":"8"}]},{"name":"kuljeet","age":26,"subjects":[{"name":"English","class":"12"},{"name":"Punjabi","class":"12"},{"name":"Math","class":"12"},{"name":"Science","class":"12"}]}]
 var data2 = JSON.parse(fs.readFileSync("./test/data2.json"));
 
+
 // Test Case 1
 describe('deepSearchForSpecificKey', function() {
   it('deep Search For Specific Key', function() {
@@ -43,5 +44,46 @@ describe('deepSearchForSpecificValueIncludePathsInResults', function() {
   it('deep search for specific value having range, include path in results', function() {
       var _res = jsonQuery({pathPropName: "__path__"}).query("$..[?year>1975]", data2);
       assert.ok(_res[1].__path__ == "['bands']['Dire Straits']['albums']['1']");
+  });
+});
+
+// Test Case 6 - Test caching
+describe('deepSearchWithCaching', function() {
+  it('deep search for specific value having range, include path in results, use cachine', function() {
+      var jq = jsonQuery({pathPropName: "__path__", cacheData: true});
+      var _res = jq.query("$..[?year>1975]", data2);
+      assert.ok(_res[1].__path__ == "['bands']['Dire Straits']['albums']['1']");
+
+      var _res2 = jq.query("$..[?year>2000]", data2);
+      assert.ok(_res2[0].__path__ == "['bands']['Morons in Suits']['albums']['0']");
+  });
+});
+
+describe('deepSearchForLargeData', function() {
+  big_data = {
+    groups: [],
+    creator: "Me"
+  };
+
+  for (i=0; i<1000; ++i) {
+    
+    var users = [];
+    for (j=0; j<1000; ++j) {
+      users.push({
+        "name": "user_" + (i+1)*(j+1),
+        "age": j
+      });
+    }
+
+    big_data['groups'].push(users);
+  }
+
+  it('deep search on large data using caching', function() {
+      var jq = jsonQuery({pathPropName: "__path__", cacheData: true});
+      var _res = jq.query("$..[?@.age>20&&@.age<50]", big_data);
+      assert.lengthOf(_res, 29000);
+
+      var _res2 = jq.query("$..[?@.age>30&&@.age<40]", big_data);
+      assert.lengthOf(_res2, 9000);
   });
 });


### PR DESCRIPTION
Added caching to the results of the _find method. The 'walk' recursive method called in 'find' method takes a lot of time to compute. By caching the results, the query can be performed a lot faster